### PR TITLE
Escape regex in device name the right way

### DIFF
--- a/app.js
+++ b/app.js
@@ -1072,19 +1072,12 @@ var firmwarewizard = function() {
     });
 
     // prepare the matches for use in regex (join by pipe and escape dots)
-    var matchString = matches.join('|').replace(/\./g, '\.');
+    var matchString = matches.map(x => x.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|');
 
     // match image files. The match either ends with
     // - a dash or dot (if a file extension will follow)
     // - the end of the expression (if the file extension is part of the regex)
     var reMatch = new RegExp('('+matchString+')([.-]|$)');
-
-    // check if image regexes contain regular expressions themself
-    var reCheckRegex = new RegExp(/[^\\]+[+?*]/);
-
-    if (reCheckRegex.exec(matches.join('|')) !== null) {
-      console.log("Warning! Some regular expressions for firmware images, contain unescaped characters.");
-    }
 
     var sitesLoadedSuccessfully = 0;
     for (var indexPath in config.directories) {

--- a/devices.js
+++ b/devices.js
@@ -131,7 +131,7 @@ var devices_recommended = {
     "UniFi AP AC Pro": "ubiquiti-unifi-ac-pro",
     "UniFi AP AC Lite": "ubiquiti-unifi-ac-lite",
     "UniFi AP Outdoor": {"ubiquiti-unifi-outdoor": "", "ubiquiti-unifiap-outdoor": ""},
-    "UniFi AP Outdoor+": {"ubiquiti-unifi-outdoor-plus": "", "ubiquiti-unifiap-outdoor\\\+": "", "ubiquiti-unifiap-outdoor%2B": "", "ubiquiti-unifiap-outdoor%2b": ""}
+    "UniFi AP Outdoor+": {"ubiquiti-unifi-outdoor-plus": "", "ubiquiti-unifiap-outdoor+": "", "ubiquiti-unifiap-outdoor%2B": "", "ubiquiti-unifiap-outdoor%2b": ""}
   },
 
   "VoCore": {


### PR DESCRIPTION
This fixes the handling of device names containing regex special chars by escaping all of them acording to `escapeRegExp` from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions.

A running instance of this can be found here: https://firmware.fulda.freifunk.net/selector/