### PR TITLE
change preview layout to css-grid

### DIFF
--- a/app.css
+++ b/app.css
@@ -239,8 +239,38 @@ h1, h2, h3, h4, h5, h6 {
   color: black;
 }
 
+#wizard .imagePreview {
+  display: grid;
+  grid-template-columns: 25% 25% 25% 25%;
+  -ms-grid-columns: 25% 25% 25% 25%;
+}
+
+@media (max-width: 960px) {
+  #wizard .imagePreview {
+    display: grid;
+    grid-template-columns: 33% 33% 33%;
+    -ms-grid-columns: 33% 33% 33%;
+  }
+}
+
+@media (max-width: 700px) {
+  #wizard .imagePreview {
+    display: grid;
+    grid-template-columns: 50% 50%;
+    -ms-grid-columns: 50% 50%;
+  }
+}
+
+@media (max-width: 500px) {
+  #wizard .imagePreview {
+    display: grid;
+    grid-template-columns: 100%;
+    -ms-grid-columns: 100%;
+  }
+}
+
 #wizard .imagePreview .preview {
-  display: inline-block;
+  display: inline-grid;
   height: 11em;
   margin: 0.5em;
   padding: 0.5em;
@@ -260,7 +290,10 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 #wizard .imagePreview .preview img {
-  height: 8em;
+  height: auto;
+  width: auto;
+  max-width: 100%;
+  max-height: 8em;
   margin-bottom: 0.5em;
 }
 


### PR DESCRIPTION
Currently, the firmware wizard displays a different number of models in each row of the preview-area, depending on the images dimensions or model name length.

![](https://i.imgur.com/9ylj0vW.png)

This commit changes the properties to display a fixed number of models per row, based on the width of the browsers window.

### 1920px
![](https://i.imgur.com/w3i1PWL.png)

### 960px
![](https://i.imgur.com/2UKdrFG.png)

### 640px
![](https://i.imgur.com/N3qHOkc.png)

### 480px
![](https://i.imgur.com/tMfpsz5.png)