### PR TITLE
rename GL Innovations to GL.iNet

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -27,12 +27,12 @@ var devices_recommended = {
     "DIR-860L": "d-link-dir-860l"
   },
 
-  "GL Innovations": {
-    "AR150": "gl-ar150",
-    "AR300M": "gl-ar300m",
-    "AR750": "gl-ar750",
-    "iNet 6408a": "gl-inet-6408a",
-    "iNet 6416a": "gl-inet-6416a",
+  "GL.iNet": {
+    "GL-AR150": "gl-ar150",
+    "GL-AR300M": "gl-ar300m",
+    "GL-AR750": "gl-ar750",
+    "6408a": "gl-inet-6408a",
+    "6416a": "gl-inet-6416a",
     "GL-B1300": "gl.inet-gl-b1300",
     "GL-MT300a": "gl-mt300a",
     "GL-MT300n": "gl-mt300n",


### PR DESCRIPTION
The company doesn't seem to be called "GL Innovations", at least nowadays.

On their website, you find a reference to "GL Technologies &
Microuter Technologies", but devices are all referred as GL.iNet GL-XXX,
so we should use this name instead.

Adjust naming of the devices accordingly.