### PR TITLE
set background-color to white

### DIFF
--- a/app.css
+++ b/app.css
@@ -9,6 +9,7 @@ body {
   font-size: 14px;
   line-height: 1.42;
   color: #333;
+  background-color: #fff;
   overflow-y: scroll;
 }
 


### PR DESCRIPTION
The `background-color` of `<body>` is grey on Firefox. This commit sets it to `white`.