### PR TITLE
make branch descriptions configurable

### DIFF
--- a/app.css
+++ b/app.css
@@ -90,6 +90,11 @@ h1, h2, h3, h4, h5, h6 {
   background: rgba(255, 255, 255, 0.8);
 }
 
+#branchName {
+  text-transform: capitalize;
+  font-weight: bold;
+}
+
 #currentVersions {
   float:right;
   padding: .5em;

--- a/app.js
+++ b/app.js
@@ -832,6 +832,7 @@ var firmwarewizard = function() {
         return branches.indexOf(a.branch) > branches.indexOf(b.branch);
       });
 
+      $('#branchdescs').innerHTML = '';
       $('#branchselect').innerHTML = '';
       $('#branch-experimental-dl').innerHTML = '';
 
@@ -848,6 +849,29 @@ var firmwarewizard = function() {
         a.innerText = rev.branch +
                       (rev.size!==''?' ['+rev.size+']':'') +
                       ' (' +prettyPrintVersion(rev.version)+')';
+
+        if (rev.branch in config.branch_descriptions) {
+          var li = document.createElement('li');
+          var name = document.createElement('span');
+          name.innerText = rev.branch;
+          name.id = 'branchName';
+          var desc = document.createElement('span');
+          desc.id = 'branchDesc'
+          desc.innerText = ' ' + config.branch_descriptions[rev.branch];
+
+          li.appendChild(name);
+
+          if (rev.branch == config.recommended_branch) {
+            var recommended = document.createElement('sup');
+            recommended.innerText = ' Empfehlung';
+            name.appendChild(recommended);
+          }
+
+          br = document.createElement('br');
+          li.appendChild(br);
+          li.appendChild(desc);
+          $('#branchdescs').appendChild(li);
+        }
 
         if (config.experimental_branches.indexOf(rev.branch) != -1) {
           if($('#branchselect .dl-experimental') === null) {

--- a/config_template.js
+++ b/config_template.js
@@ -30,6 +30,14 @@ var config = {
     './images/gluon-factory-example.html': 'stable',
     './images/gluon-sysupgrade-example.html': 'stable'
   },
+  // branch descriptions shown during selection
+  branch_descriptions: {
+    stable: 'Gut getestet, zuverlässig und stabil.',
+    beta: 'Vorabtests neuer Stable-Kandidaten.',
+    experimental: 'Ungetestet, automatisch generiert.'
+  },
+  // recommended branch will be marked during selection
+  recommended_branch: 'stable',
   // experimental branches (show a warning for these branches)
   experimental_branches: ['experimental'],
   // path to preview pictures directory

--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@
             <em>Upgrade</em> bezeichnete Version.
           </p>
           <p>
-            Einige Geräte benötigen spezielle Images, welche über den Bootloader 
+            Einige Geräte benötigen spezielle Images, welche über den Bootloader
             des Herstellers eingespiel werden.
           </p>
           <radiogroup id="typeselect" class="radiogroup"></radiogroup>
@@ -57,20 +57,7 @@
         <div id="branch-pane" class="pane initiallyhidden">
           <h1>Schritt 3: Wähle Deinen Update-Kanal</h1>
           <p>Diese Freifunk-Firmware bieten wir in verschiedenen Versionen an:</p>
-          <ul>
-            <li>
-              <strong>Stable <sup>Empfehlung</sup></strong><br />
-              Gut getestet, zuverl&auml;ssig und stabil.<br />
-            </li>
-            <li>
-              <strong>Beta</strong><br />
-              Vorabtests neuer Stable-Kandidaten.<br />
-            </li>
-            <li>
-              <strong>Experimental</strong><br />
-              Ungetestet, automatisch generiert.<br />
-            </li>
-          </ul>
+          <ul id="branchdescs"></ul>
           <p>Die Auswahl der passenden Version entscheidet &uuml;ber die
              Stablit&auml;t des Routers und den potentiell anfallenden
              Wartungsaufwand.</p>


### PR DESCRIPTION
Branch names may differ between communities but the names, descriptions and which one is recommended is hardcoded in the _index.html_ file. This patch makes them configurable.

A string for each branch that is defined in `directories` can be set via `branch_descriptions` and is looked up during the selection process. In addition you can decide which branch is marked as recommended by setting `recommended_branch`.
```
...
  directories: {
    // some demo sources
    './images/gluon-factory-example.html': 'stable',
    './images/gluon-sysupgrade-example.html': 'stable'
  },
  // branch descriptions shown during selection
  branch_descriptions: {
    stable: 'Gut getestet, zuverlässig und stabil.',
    beta: 'Vorabtests neuer Stable-Kandidaten.',
    experimental: 'Ungetestet, automatisch generiert.'
  },
  // recommended branch will be marked during selection
  recommended_branch: 'stable',
  // experimental branches (show a warning for these branches)
  experimental_branches: ['experimental'],
...
```