### PR TITLE
ignore nexx-wt3020-8m image

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -79,7 +79,7 @@ var devices_recommended = {
   },
 
   "Nexx": {
-    "WT3020": {"nexx-wt3020-8m": "8M"},
+    "WT3020": {"nexx-wt3020-8m": "--ignore--"},
     "WT3020AD": "nexx-wt3020ad",
     "WT3020F": "nexx-wt3020f",
     "WT3020H": "nexx-wt3020h",


### PR DESCRIPTION
There is no WT3020 8M model. It is just the unified image for WT3020AD/F/H.