### PR TITLE
Include revision in getImageTypes() filter

### DIFF
--- a/app.js
+++ b/app.js
@@ -527,7 +527,9 @@ var firmwarewizard = function() {
     if (modelList.length == 1) {
       var vendor = modelList[0][MODEL_VENDOR];
       var model = modelList[0][MODEL_MODEL];
+      var revision = modelList[0][MODEL_MATCHED_REVISION];
       return images[vendor][model]
+        .filter(function(value, index, self) { return value['revision'] == revision; })
         .map(function(e) { return e.type; })
         .filter(function(value, index, self) { return self.indexOf(value) === index; })
         .sort();


### PR DESCRIPTION
Revisions of one device might have different available images.

For example only v3 of the TP-Link Archer C50 has a bootloader image.
But without filtering a button "Bootloader-Image" would also be shown
for the v4 (and all future revisions).

Version with applied fix:
v3: https://wizard.freifunk-mwu.de/?q=TP-Link%E2%81%A3%20Archer%C2%A0C50%E2%81%A3%20v3%E2%81%A3
v4: https://wizard.freifunk-mwu.de/?q=TP-Link%E2%81%A3%20Archer%C2%A0C50%E2%81%A3%20v4%E2%81%A3