### PR TITLE
fix RegExp FileExtension

### DIFF
--- a/app.js
+++ b/app.js
@@ -120,7 +120,7 @@ var firmwarewizard = function() {
     return index === self.indexOf(e);
   });
 
-  var reFileExtension = new RegExp(/.(bin|img.gz|img|tar|ubi)/);
+  var reFileExtension = new RegExp(/.(bin|img\.gz|img|tar|ubi)$/);
   var reRemoveDashes = new RegExp(/-/g);
   var reSearchable = new RegExp('[-/ '+NON_BREAKING_SPACE+']', 'g');
   var reRemoveSpaces = new RegExp(/ /g);

--- a/app.js
+++ b/app.js
@@ -120,7 +120,7 @@ var firmwarewizard = function() {
     return index === self.indexOf(e);
   });
 
-  var reFileExtension = new RegExp(/.(bin|img\.gz|img|tar|ubi)$/);
+  var reFileExtension = new RegExp(/\.(bin|img\.gz|img|tar|ubi)$/);
   var reRemoveDashes = new RegExp(/-/g);
   var reSearchable = new RegExp('[-/ '+NON_BREAKING_SPACE+']', 'g');
   var reRemoveSpaces = new RegExp(/ /g);


### PR DESCRIPTION
reFileExtension had a problem caused false replacing of extensions 
(for examble extension "ubi" replaced ubi in ubiquity and left extension "bin")

e.g. file:
gluon-comm-0.1.2-stable.0-20190722-ubiquiti-unifi-ac-mesh-sysupgrade.bin

would have been (wrong):
quiti-unifi-ac-mesh-.bin.jpg

instead of (correct): 
ubiquiti-unifi-ac-mesh.jpg

should fix (at least parts) of #92 


not sure if the first dot in line 123 should also be escaped
RegExp(/.(bin|img\\.gz|img|tar|ubi)$/);
RegExp(/\\.(bin|img\\.gz|img|tar|ubi)$/);