### PR TITLE
two small improvements around regex

### DIFF
--- a/app.js
+++ b/app.js
@@ -356,7 +356,6 @@ var firmwarewizard = function() {
   }
 
   function findVersion(name) {
-    // version with optional date in it (e.g. 0.8.0~20160502)
     var m = reVersionRegex.exec(name);
     return m ? m[1] : '';
   }

--- a/config_template.js
+++ b/config_template.js
@@ -29,7 +29,7 @@ var config = {
   // community prefix of the firmware images
   community_prefix: 'gluon-ffda-',
   // firmware version regex
-  version_regex: '-([0-9]+.[0-9]+.[0-9]+([+-~][0-9]+)?)[.-]',
+  version_regex: /-([\d]+\.[\d]+\.[\d]+([+-~][\d]+)?)[.-]/,
   // relative image paths and branch
   directories: {
     // some demo sources


### PR DESCRIPTION
one commit removes a source code comment as the text of the comment would only apply to the example config (ffda version scheme)

2nd commit replaces the regex used for version detection with a "real" regex instead of a string.