### PR TITLE
Add list for flash instructions

### DIFF
--- a/app.css
+++ b/app.css
@@ -186,7 +186,8 @@ h1, h2, h3, h4, h5, h6 {
   color: #009ee0;
 }
 
-#wizard #branch-pane .btn {
+#wizard #branch-pane .btn,
+#wizard #type-pane .btn {
   background-color: #009ee0;
 }
 
@@ -194,8 +195,13 @@ h1, h2, h3, h4, h5, h6 {
   box-shadow: 0 0 0.5em #005ea0 inset;
 }
 
+#wizard #type-pane.show-deviceinfo-warning button.deviceinfo {
+  box-shadow: 0 0 0.5em #005ea0 inset;
+}
+
 #wizard #branch-pane .warning-experimental,
-#wizard #model-pane .warning-notrecommended {
+#wizard #model-pane .warning-notrecommended,
+#wizard #type-pane .warning-deviceinfo {
   display: none;
   margin: 1em 0;
   padding: 1em;
@@ -204,7 +210,8 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 #wizard #branch-pane.show-experimental-warning .warning-experimental,
-#wizard #model-pane.show-notrecommended-warning .warning-notrecommended {
+#wizard #model-pane.show-notrecommended-warning .warning-notrecommended,
+#wizard #type-pane.show-deviceinfo-warning .warning-deviceinfo {
   display: block;
 }
 

--- a/app.js
+++ b/app.js
@@ -819,6 +819,39 @@ var firmwarewizard = function() {
         scrollDown();
       }
 
+      var deviceinfo = $('#deviceinfo');
+      var url = '';
+      deviceinfo.innerHTML = '';
+
+      if (
+        devices_info[currentVendor] !== undefined &&
+        devices_info[currentVendor][currentModel] !== undefined
+      ) {
+        url = devices_info[currentVendor][currentModel];
+      }
+
+      if (
+        config.devices_info !== undefined &&
+        config.devices_info[currentVendor] !== undefined &&
+        config.devices_info[currentVendor][currentModel]
+      ) {
+        url = config.devices_info[currentVendor][currentModel];
+      }
+
+      if (url !== '') {
+        setClass($('#type-pane'), 'show-deviceinfo-warning', true);
+
+        var a = document.createElement('a');
+        a.href = url;
+        a.className = 'btn';
+        a.target = '_blank';
+        a.innerText = 'Anleitung';
+
+        deviceinfo.appendChild(a);
+      } else {
+        setClass($('#type-pane'), 'show-deviceinfo-warning', false);
+      }
+
       var typeselect = $('#typeselect');
       typeselect.innerHTML = '';
 

--- a/config_template.js
+++ b/config_template.js
@@ -52,5 +52,12 @@ var config = {
   // path to preview pictures directory
   preview_pictures: 'pictures/',
   // link to changelog
-  changelog: 'CHANGELOG.html'
+  changelog: 'CHANGELOG.html',
+  // links for instructions like flashing of certain devices (optional)
+  // overwrites values from devices_info in devices.js
+  devices_info: {
+    'AVM': {
+      "FRITZ!Box 4040": "https://fritz-tools.readthedocs.io"
+    }
+  }
 };

--- a/devices.js
+++ b/devices.js
@@ -380,3 +380,18 @@ var vendormodels = {
   "8_32": devices_8_32,
   "16_32": devices_16_32,
 }
+
+var devices_info = {
+  "AVM": {
+    "FRITZ!Box 4020": "https://fritzfla.sh",
+    "FRITZ!Box 4040": "https://fritzfla.sh",
+    "FRITZ!Box 7312": "https://fritzfla.sh",
+    "FRITZ!Box 7320": "https://fritzfla.sh",
+    "FRITZ!Box 7330": "https://fritzfla.sh",
+    "FRITZ!Box 7330 SL": "https://fritzfla.sh",
+    "FRITZ!Box 7360": "https://fritzfla.sh",
+    "FRITZ!Box 7360 SL": "https://fritzfla.sh",
+    "FRITZ!WLAN Repeater 300E": "https://fritzfla.sh",
+    "FRITZ!WLAN Repeater 450E": "https://fritzfla.sh"
+  }
+}

--- a/index.html
+++ b/index.html
@@ -66,6 +66,14 @@
             Einige Geräte benötigen spezielle Images, welche über den Bootloader
             des Herstellers eingespielt werden.
           </p>
+          <div class="warning-deviceinfo">
+            <b>Vorsicht!</b> Für dieses Gerät gibt es eine extra Anleitung.
+            Dies kann zum Beispiel bedeuten, dass die Installation nicht über die
+            Weboberfläche des Geräts möglich ist. Bitte besuche zuerst die folgende
+            Seite und lies dir alle Informationen gut durch bevor du mit dem
+            Flashen der Firmware beginnst.
+            <div id="deviceinfo"></div>
+          </div>
           <radiogroup id="typeselect" class="radiogroup"></radiogroup>
         </div>
       </div>


### PR DESCRIPTION
I added an array of links to for devices with which need special flash instructions.

It is rather simple and tries to find an entry in a list called `devices_info` in _devices.js_.

```
var devices_info = {
  "AVM": {
    "FRITZ!Box 4020": "https://fritzfla.sh",
    ...
  }
  ...
}
```

A community can also overwrite the defined links via a `devices_info` list in their _config.js_

```
var config = {
  ....
  // links for instructions like flashing of certain devices (optional)
  // overwrites values from devices_info in devices.js
  devices_info: {
    'AVM': {
      "FRITZ!Box 4040": "https://fritz-tools.readthedocs.io"
    }
  }
};
```

**example**
![Screenshot_20200406_232425](https://user-images.githubusercontent.com/915117/78607713-e3f60980-785f-11ea-9d71-24f73f50431b.png)

The text is just a first example and suggestions are welcome ;-)

Should Fix #95 