### PR TITLE
devices: fix name of FRITZ!Repeater 1200

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -403,7 +403,7 @@ var devices_info = {
     "FRITZ!Box 7330 SL": "https://fritzfla.sh",
     "FRITZ!Box 7360": "https://fritzfla.sh",
     "FRITZ!Box 7360 SL": "https://fritzfla.sh",
-    "FRITZ!WLAN Repeater 1200": "https://git.openwrt.org/?p=openwrt/openwrt.git;a=commit;h=7f187229a8e9b7966248b1e024217e07a9fc3e50",
+    "FRITZ!Repeater 1200": "https://git.openwrt.org/?p=openwrt/openwrt.git;a=commit;h=7f187229a8e9b7966248b1e024217e07a9fc3e50",
     "FRITZ!WLAN Repeater 300E": "https://fritzfla.sh",
     "FRITZ!WLAN Repeater 450E": "https://fritzfla.sh"
   }


### PR DESCRIPTION
Der Name des `FRITZ!Repeater 1200` stimmt in den Installatonsanweisungen nicht. Dadurch funktioniert das Anzeigen des Anleitungs-Links nicht. Dies sollte das beheben.

Damit ist er auch identisch zu der Zeile 

https://github.com/freifunk-darmstadt/gluon-firmware-selector/blob/2e857f83d08c0d24ec8a6dd5e20708693447d74d/devices.js#L37

in der Definition für das Firmware Image.