### PR TITLE
app: allow device info links per revision

### DIFF
--- a/app.js
+++ b/app.js
@@ -839,23 +839,36 @@ var firmwarewizard = function() {
         scrollDown();
       }
 
-      var deviceinfo = $('#deviceinfo');
-      var url = '';
-      deviceinfo.innerHTML = '';
+      // find device info link
+      function findDeviceInfo(vendor, model, revision, links) {
+        if (links[vendor] !== undefined && links[vendor][model] !== undefined) {
+          revisions = links[vendor][model];
+        } else {
+          return '';
+        }
 
-      if (
-        devices_info[currentVendor] !== undefined &&
-        devices_info[currentVendor][currentModel] !== undefined
-      ) {
-        url = devices_info[currentVendor][currentModel];
+        if (typeof revisions == 'object' && revisions[revision] !== undefined) {
+          return revisions[revision];
+        } else if (typeof revisions == 'string') {
+          return revisions;
+        } else {
+          return '';
+        }
       }
 
-      if (
-        config.devices_info !== undefined &&
-        config.devices_info[currentVendor] !== undefined &&
-        config.devices_info[currentVendor][currentModel]
-      ) {
-        url = config.devices_info[currentVendor][currentModel];
+      var url = '';
+      var custom_url = '';
+      var deviceinfo = $('#deviceinfo');
+      deviceinfo.innerHTML = '';
+
+      url = findDeviceInfo(currentVendor, currentModel, currentRevision, devices_info);
+
+      if ("devices_info" in config){
+        custom_url = findDeviceInfo(currentVendor, currentModel, currentRevision, config.devices_info);
+      }
+
+      if (custom_url !== '') {
+        url = custom_url;
       }
 
       if (url !== '') {

--- a/config_template.js
+++ b/config_template.js
@@ -54,10 +54,14 @@ var config = {
   // link to changelog
   changelog: 'CHANGELOG.html',
   // links for instructions like flashing of certain devices (optional)
-  // overwrites values from devices_info in devices.js
-  devices_info: {
-    'AVM': {
-      "FRITZ!Box 4040": "https://fritz-tools.readthedocs.io"
-    }
-  }
+  // can be set for a whole model or individual revisions
+  // overwrites default values from devices_info in devices.js
+  // devices_info: {
+  //   'AVM': {
+  //     "FRITZ!Box 4040": "https://fritz-tools.readthedocs.io"
+  //   },
+  //   "TP-Link": {
+  //     "TL-WR841N/ND": {"v13": "https://wiki.freifunk.net/TP-Link_WR841ND/Flash-Anleitung_v13"}
+  //   }
+  // }
 };

--- a/devices.js
+++ b/devices.js
@@ -428,5 +428,10 @@ var devices_info = {
     "UniFi AC Mesh Pro": "https://forum.darmstadt.freifunk.net/t/unifi-ap-erstinstallation/790",
     "UniFi AC Mesh": "https://forum.darmstadt.freifunk.net/t/unifi-ap-erstinstallation/790",
     "UniFi AC Pro": "https://forum.darmstadt.freifunk.net/t/unifi-ap-erstinstallation/790",
+  },
+  "TP-Link": {
+    "TL-WR841N/ND" : {
+      "v13": "https://openwrt.org/toh/tp-link/tl-wr841nd#tftp_recovery_via_bootloader_for_v8_v9_v10_v11_v12_v13"
+    }
   }
 }


### PR DESCRIPTION
I adjusted the devices_info code to allow setting links per revision.

Probably not the nicest JavaScript code but I couldn't find any problems during my tests.

Fixes #79 