### PR TITLE
app: add bootloader images to table view

### DIFF
--- a/app.js
+++ b/app.js
@@ -1018,6 +1018,9 @@ var firmwarewizard = function() {
     $('#firmwareTableBody').innerHTML = '';
 
     var initializeRevHTML = function(rev) {
+      if (bootloaderRevBranchDict[rev.branch] === undefined) {
+        bootloaderRevBranchDict[rev.branch] = document.createElement('span');
+      }
       if (upgradeRevBranchDict[rev.branch] === undefined) {
         upgradeRevBranchDict[rev.branch] = document.createElement('span');
       }
@@ -1044,6 +1047,11 @@ var firmwarewizard = function() {
         factoryRevBranchDict[rev.branch].appendChild(textNodeStart);
         factoryRevBranchDict[rev.branch].appendChild(a);
         factoryRevBranchDict[rev.branch].appendChild(textNodeEnd);
+        show = true;
+      } else if (rev.type == 'bootloader') {
+        bootloaderRevBranchDict[rev.branch].appendChild(textNodeStart);
+        bootloaderRevBranchDict[rev.branch].appendChild(a);
+        bootloaderRevBranchDict[rev.branch].appendChild(textNodeEnd);
         show = true;
       }
     };
@@ -1075,6 +1083,7 @@ var firmwarewizard = function() {
         var revisions = sortByRevision(images[vendor][model]);
         var upgradeRevBranchDict = {};
         var factoryRevBranchDict = {};
+        var bootloaderRevBranchDict = {};
         var show = false;
 
         revisions.forEach(initializeRevHTML);
@@ -1094,6 +1103,7 @@ var firmwarewizard = function() {
         tdModel.innerText = model;
         tr.appendChild(tdModel);
 
+        tr.appendChild(createRevTd(bootloaderRevBranchDict));
         tr.appendChild(createRevTd(factoryRevBranchDict));
         tr.appendChild(createRevTd(upgradeRevBranchDict));
 

--- a/index.html
+++ b/index.html
@@ -111,13 +111,14 @@
           <tr>
             <th>Hersteller</th>
             <th>Modell</th>
+            <th>Bootloader-Image</th>
             <th>Erstinstallation</th>
             <th>Upgrade</th>
           </tr>
         </thead>
         <tbody id="firmwareTableBody">
           <tr>
-            <td colspan="4">Loading...</td>
+            <td colspan="5">Loading...</td>
           </tr>
         </tbody>
       </table>


### PR DESCRIPTION
This commit adds bootloader images to the column "Erstinstallation" in the table view. As devices with bootloader images should not have factory images I don't see a need to add an extra column which is empty for almost all devices.

Fixes #91