### PR TITLE
app: always uncheck "not recommended" checkbox

### DIFF
--- a/app.js
+++ b/app.js
@@ -227,6 +227,8 @@ var firmwarewizard = function() {
       document.title = config.title;
     }
 
+    $('#notrecommendedselect').checked = false;
+
     function parseURLasJSON() {
       var search = location.search.substring(1);
       return search ? JSON.parse(


### PR DESCRIPTION
When testing #109 I noticed that the checkbox for not recommended devices was kept checked during a page reload but the corresponding devices were not shown. This patch unckecks the checkbox during page load.