### PR TITLE
devices: add Linksys EA6350 (v3)

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -276,6 +276,12 @@ var devices_ath10k_lowmem = {
 	},
 };
 
+var devices_small_kernel_part = {
+  "Linksys": {
+    "EA6350": {"linksys-ea6350v3": "v3"}
+  }
+};
+
 var devices_4_32 = {
 
   "D-Link": {
@@ -382,6 +388,7 @@ var devices_16_32 = {
 var vendormodels = {
   "recommended": devices_recommended,
   "ath10k_lowmem": devices_ath10k_lowmem,
+  "small_kernel_part": devices_small_kernel_part,
   "4_32": devices_4_32,
   "8_32": devices_8_32,
   "16_32": devices_16_32,


### PR DESCRIPTION
Due to the known limitations of the device (see https://github.com/freifunk-gluon/gluon/pull/2008) and an average price of 80€ we should list it in the recommend devices.

This PR introduces a new device category "small_kernel_part" and communities can decide if they want to list the device or not.