### PR TITLE
fixup! app: filter vendors without images for enabled device categories

### DIFF
--- a/app.js
+++ b/app.js
@@ -727,9 +727,11 @@ var firmwarewizard = function() {
 
   function hasVendorDevicesForEnabledDeviceCategories(vendor) {
     var image_vendors = Object.keys(images);
-    for (let [key, value] of Object.entries(images[vendor])) {
-      if (enabled_device_categories.includes(value[0].category)) {
-        return true;
+    if (images[vendor]) {
+      for (let [key, value] of Object.entries(images[vendor])) {
+        if (enabled_device_categories.includes(value[0].category)) {
+          return true;
+        }
       }
     }
     return false;


### PR DESCRIPTION
Without the if it was possible that images[vendor] was undefined because
their was no image available for that vendor.
And then `Object.entries(images[vendor])` resulted in:

Uncaught TypeError: Cannot convert undefined or null to object

And this led to the problem that no device at all was shown :(

Related to d45019d10513ce0306c66d7744cbcd8fbe25683c, #118 