### PR TITLE
devices: rename PI to PI1 for less confusion

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -165,7 +165,7 @@ var devices_recommended = {
   },
 
   "Raspberry Pi Foundation": {
-    "PI": { "raspberry-pi": "", "raspberrypi-model-b": "" },
+    "PI1": { "raspberry-pi": "", "raspberrypi-model-b": "" },
     "PI2": { "raspberry-pi-2": "", "raspberrypi-2-model-b": "" },
     "PI3": { "raspberry-pi-3": "", "raspberrypi-3-model-b": "" }
   },


### PR DESCRIPTION
To me it seems like naming the PI"1" image only PI could cause confusion. The name "PI" might suggest to some that this image works with the other PIs which aren't mentioned seperatly (currently PI1 and PI4).