### PR TITLE
Change info link for Fritz! devices

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -407,17 +407,17 @@ var devices_info = {
     "Instant On AP11": "https://git.openwrt.org/?p=openwrt/openwrt.git;a=commit;h=102c8c55f217606cdbdc9a449667e034676b3e75"
   },
   "AVM": {
-    "FRITZ!Box 4020": "https://fritzfla.sh",
-    "FRITZ!Box 4040": "https://fritzfla.sh",
-    "FRITZ!Box 7312": "https://fritzfla.sh",
-    "FRITZ!Box 7320": "https://fritzfla.sh",
-    "FRITZ!Box 7330": "https://fritzfla.sh",
-    "FRITZ!Box 7330 SL": "https://fritzfla.sh",
-    "FRITZ!Box 7360": "https://fritzfla.sh",
-    "FRITZ!Box 7360 SL": "https://fritzfla.sh",
+    "FRITZ!Box 4020": "https://fritz-tools.readthedocs.io/",
+    "FRITZ!Box 4040": "https://fritz-tools.readthedocs.io/",
+    "FRITZ!Box 7312": "https://fritz-tools.readthedocs.io/",
+    "FRITZ!Box 7320": "https://fritz-tools.readthedocs.io/",
+    "FRITZ!Box 7330": "https://fritz-tools.readthedocs.io/",
+    "FRITZ!Box 7330 SL": "https://fritz-tools.readthedocs.io/",
+    "FRITZ!Box 7360": "https://fritz-tools.readthedocs.io/",
+    "FRITZ!Box 7360 SL": "https://fritz-tools.readthedocs.io/",
     "FRITZ!Repeater 1200": "https://git.openwrt.org/?p=openwrt/openwrt.git;a=commit;h=7f187229a8e9b7966248b1e024217e07a9fc3e50",
-    "FRITZ!WLAN Repeater 300E": "https://fritzfla.sh",
-    "FRITZ!WLAN Repeater 450E": "https://fritzfla.sh"
+    "FRITZ!WLAN Repeater 300E": "https://fritz-tools.readthedocs.io/",
+    "FRITZ!WLAN Repeater 450E": "https://fritz-tools.readthedocs.io/"
   },
   "devolo": {
     "WiFi Pro 1200e": "https://git.openwrt.org/?p=openwrt/openwrt.git;a=commit;h=1724d4e9ed7716a5444eca42adf045c2f3afc554",


### PR DESCRIPTION
fritzfla.sh seems to be defunct, so switching to link provided by openwrt.