### PR TITLE
pictures: fixup #131 (symlink for cpe510-v3 was missing)

### DIFF
--- a/pictures/tp-link-cpe510-v3.jpg
+++ b/pictures/tp-link-cpe510-v3.jpg
@@ -1,0 +1,1 @@
+tp-link-cpe210-v1.jpg


### PR DESCRIPTION
I forgot to add the symlink for `tp-link-cpe510-v3.jpg` 

Sorry for the additional work 😅