### PR TITLE
app: "veraltete Geräte" -> "nicht empfohlene Geräte"

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
       <a href="./index.html"><img src="./router.png" ></a>
       <div class="pane-wrapper">
         <div id="model-pane" class="pane">
-          <span class="notRecommendedLink">Veraltete Geräte anzeigen</span>
+          <span class="notRecommendedLink">nicht empfohlene Geräte anzeigen</span>
           <span class="firmwareTableLink">Tabelle anzeigen</span>
           <h1>Schritt 1: Wähle Dein Routermodell</h1>
           <div class="warning-notrecommended">
@@ -28,13 +28,13 @@
               Freifunk-Betrieb gewährleistet.
             </p>
             <p>
-              Bevor du veraltete Geräte verwendest, solltest du dich selbst über die Konsequenzen
+              Bevor du nicht empfohlene Geräte verwendest, solltest du dich selbst über die Konsequenzen
               und technischen Hintergründe informieren und dich Entscheiden, ob Du wirklich alle
               Nachteile in Kauf nehmen willst.
             </p>
             <div id="notrecommendedinfo"></div>
             <input type="checkbox" id="notrecommendedselect" class="notRecommendedCheckbox" value="notRecommended" />
-            <label class="notRecommendedLabel" for="notrecommendedselect">Veraltete Geräte trotzdem anzeigen</label>
+            <label class="notRecommendedLabel" for="notrecommendedselect">nicht empfohlene Geräte trotzdem anzeigen</label>
           </div>
           <p>Erst mit der Freifunk-Firmware wird dein Router zu einem Teil des
              Freifunk-Netzes. Sie ist fertig vorkonfiguriert, um Kontakt mit


### PR DESCRIPTION
Ursprünglich hatten wir das Feature zu anzeigen nicht (mehr) unterstützter Geräte für die Geräte mit nur 32MB RAM bzw. 4MB Flash eingeführt. Dementsprechend hatten wir als Text "veraltete Geräte" gewählt. Mit der Zeit kamen aber mehrere Kategorien in der devices.js hinzu, so dass die Bezeichnung nicht mehr passt.