### PR TITLE
contrib/update-images.sh: download multiple branches and other dir

### DIFF
--- a/contrib/update-images.sh
+++ b/contrib/update-images.sh
@@ -1,10 +1,15 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-FACTORY="https://firmware.darmstadt.freifunk.net/images/stable/factory/"
-SYSUPGRADE="https://firmware.darmstadt.freifunk.net/images/stable/sysupgrade/"
+set -e
 
-mkdir images
+for BRANCH in "stable" "beta" "testing";
+do
+	echo "updating ${BRANCH}"
 
-curl -o images/gluon-factory-example.html "$FACTORY"
-curl -o images/gluon-sysupgrade-example.html "$SYSUPGRADE"
+	mkdir -p images/${BRANCH}
 
+	curl -sSfo images/${BRANCH}/gluon-factory-example.html "https://firmware.darmstadt.freifunk.net/images/${BRANCH}/factory/"
+	curl -sSfo images/${BRANCH}/gluon-other-example.html "https://firmware.darmstadt.freifunk.net/images/${BRANCH}/other/"
+	curl -sSfo images/${BRANCH}/gluon-sysupgrade-example.html "https://firmware.darmstadt.freifunk.net/images/${BRANCH}/sysupgrade/"
+
+done


### PR DESCRIPTION
This modifies the script to download multiple branches and store them in subfolders. 

The structure which results from this is however not the one which is given in the `config_template.js`.

However the `version_regex` there also afaik doesn't fit to the current Darmstadt versioning.