### PR TITLE
add recovery as image type

### DIFF
--- a/app.js
+++ b/app.js
@@ -114,6 +114,7 @@ var firmwarewizard = function() {
 
   var typeNames = {
     'factory': 'Erstinstallation',
+    'recovery': 'Recovery-Install-Image',
     'sysupgrade': 'Upgrade',
     'rootfs': "Root-Image",
     'kernel': "Kernel-Image",
@@ -359,7 +360,7 @@ var firmwarewizard = function() {
   }
 
   function findType(name) {
-    var m = /-(sysupgrade|factory|rootfs|kernel|eva-filesystem|eva-kernel|bootloader)[-.]/.exec(name);
+    var m = /-(sysupgrade|factory|rootfs|kernel|recovery|eva-filesystem|eva-kernel|bootloader)[-.]/.exec(name);
     return m ? m[1] : 'factory';
   }
 


### PR DESCRIPTION
I am drafting a PR for this, as this is currently only useful for the COVR-X1860 (not yet supported) and might be useful for the DAP-X1860 too

A revoery image is used for devices which can be installed with an unsigned image through a recovery instead of using the factory image through the web gui.

