### PR TITLE
index.html: simplify attribution for the pictures

### DIFF
--- a/index.html
+++ b/index.html
@@ -125,7 +125,7 @@
       </table>
     </div>
 
-    <p class="floatingBottomRight">Diese Webseite ist <a href="https://github.com/freifunk-darmstadt/gluon-firmware-wizard">freie Software</a>! Die Bilder der Router stammen von <a href="https://github.com/Moorviper/Freifunk-Router-Anleitungen">Daniel Krah</a>, <a href="https://github.com/belzebub40k/router-pics">Julian Labus</a>, <a href="https://github.com/nalxnet/freifunk-device-images">Jan Alexander</a> sowie <a href="https://github.com/freifunkstuff/meshviewer-hwimages">freifunkstuff</a> und sind lizenziert unter <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">CC-BY-NC-SA 4.0</a>.</p>
+    <p class="floatingBottomRight">Diese Webseite ist <a href="https://github.com/freifunk-darmstadt/gluon-firmware-wizard">freie Software</a>! Die <a href="https://github.com/freifunk/device-pictures">Bilder</a> sind lizenziert unter <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">CC-BY-NC-SA 4.0</a>.</p>
 
     <script src="devices.js"></script>
     <script src="config.js"></script>


### PR DESCRIPTION
Licensing isn't the simplest topic. Hoewer, i would like to simplify our attribution text.

Currently we list four Repository alongside with the Name of the "Owner".
Hoewer, the Repo Owner isn't always the Creator of those pictures.

Judging by the Contributors to those Repos at least 8 people (@Moorviper, @DeusFigendi @belzebub40k, @AiyionPrime, @nalxnet, @herbetom, @dunjii, @maurerle (i really hope i didn't overlook someone :see_no_evil:)) contributed pictures so far.

@maurerle started a Repo in the @freifunk Org to collect all those picutres in a common place:
https://github.com/freifunk/device-pictures

In the README of that Repo are all used Repos listed.

My proposal would be to just link that Repo going forward.

I would like to hear if there are any thoughts on this (in agreement or disagreement) and what alternative approaches could be.