### PR TITLE
fix: follow preview folder for placefolder image

### DIFF
--- a/app.js
+++ b/app.js
@@ -704,7 +704,7 @@ var firmwarewizard = function() {
   }
 
   function setDefaultImg(e) {
-    fallbackImg = 'pictures/no_picture_available.jpg';
+    fallbackImg = PREVIEW_PICTURES_DIR + 'no_picture_available' + PREVIEW_PICTURES_EXT;
     if (e.target.src.indexOf(fallbackImg) == -1) {
       e.target.src = fallbackImg;
     }


### PR DESCRIPTION
This allows to use an external placerholder image, like the one from https://github.com/freifunk/device-pictures/blob/main/pictures-svg/no_picture_available.svg