### PR TITLE
Add CI and improve Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,7 +3,7 @@
 README.md
 LICENSE
 *.png
+!router.png
 !pictures/*.png
 .docker
 !.docker/*
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check JS syntax
+        run: |
+          node --check app.js
+          node --check devices.js
+          node --check config_template.js
+
+  docker:
+    runs-on: ubuntu-latest
+    needs: lint
+    strategy:
+      matrix:
+        docker-target:
+          - "bundled-pictures"
+          - "external-pictures"
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Prepare config.js
+        run: cp config_template.js config.js
+
+      - name: Build ${{ matrix.docker-target }} target
+        run: docker build --target ${{ matrix.docker-target }} -t gluon-firmware-selector:${{ matrix.docker-target }} .
+
+      - name: Smoke test container
+        run: |
+          docker run -d --rm --name test-container -p 8080:80 gluon-firmware-selector:${{ matrix.docker-target }}
+          sleep 5
+          curl --fail http://localhost:8080/
+          docker stop test-container

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,17 @@
-FROM nginx:alpine
+# syntax=docker/dockerfile:1.19
+FROM nginx:alpine AS base
 
-COPY . /usr/share/nginx/html/
-COPY .docker/nginx-vhost.conf /etc/nginx/conf.d/default.conf 
+COPY --exclude=pictures . /usr/share/nginx/html/
+COPY .docker/nginx-vhost.conf /etc/nginx/conf.d/default.conf
 
 HEALTHCHECK --interval=1m --timeout=10s \
-	CMD nc -z localhost 80 
+	CMD nc -z localhost 80
 
 VOLUME ["/images"]
+
+
+FROM base AS external-pictures
+
+
+FROM base AS bundled-pictures
+COPY pictures/ /usr/share/nginx/html/pictures/

--- a/README.md
+++ b/README.md
@@ -33,8 +33,14 @@ For testing purposes or to share files in a LAN, Python can be used. Run `python
 #### Docker
 ```
 docker build -t gluon-firmware-selector .
-docker run -p 80:80 -v /path/to/firmware/:/images:ro -v /path/to/config.js:/usr/share/nginx/html/config.js:ro --name web_firmware gluon-firmware-selector
+docker run -p 80:80 \
+  -v /path/to/firmware/:/images:ro \
+  -v /path/to/config.js:/usr/share/nginx/html/config.js:ro \
+  --name web_firmware gluon-firmware-selector
 ```
+
+The `directories` in `config.js` must match your mount layout. For example, if you use `/images/stable/factory` etc. as your default firmware layout (instead of `/images/factory`), use `'/images/stable/factory/'` in `directories`.
+
 For https support check [jrcs/letsencrypt-nginx-proxy-companion](https://hub.docker.com/r/jrcs/letsencrypt-nginx-proxy-companion)
 
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,18 @@ The `directories` in `config.js` must match your mount layout. For example, if y
 
 For https support check [jrcs/letsencrypt-nginx-proxy-companion](https://hub.docker.com/r/jrcs/letsencrypt-nginx-proxy-companion)
 
+#### Docker with external device-pictures
+
+In order to use the official [device-pictures repo](https://github.com/freifunk/device-pictures), pass `--target external-pictures` to build an image without the bundled pictures.
+
+```sh
+docker build --target external-pictures -t gluon-firmware-selector .
+docker run -p 80:80 \
+  -v /path/to/firmware/:/images:ro \
+  -v /path/to/config.js:/usr/share/nginx/html/config.js:ro \
+  -v /path/to/device-pictures/pictures-svg:/usr/share/nginx/html/pictures:ro \
+  --name web_firmware gluon-firmware-selector
+```
 
 ### List of available router models
 All available router models are specified in `devices.js` via that will match against the filenames.

--- a/config_template.js
+++ b/config_template.js
@@ -33,15 +33,15 @@ var config = {
   // relative image paths and branch
   directories: {
     // some demo sources
-    './images/stable/gluon-factory-example.html': 'stable',
-    './images/stable/gluon-other-example.html': 'stable',
-    './images/stable/gluon-sysupgrade-example.html': 'stable',
-    './images/beta/gluon-factory-example.html': 'beta',
-    './images/beta/gluon-other-example.html': 'beta',
-    './images/beta/gluon-sysupgrade-example.html': 'beta',
-    './images/testing/gluon-factory-example.html': 'testing',
-    './images/testing/gluon-other-example.html': 'testing',
-    './images/testing/gluon-sysupgrade-example.html': 'testing',
+    '/images/stable/factory/': 'stable',
+    '/images/stable/other/': 'stable',
+    '/images/stable/sysupgrade/': 'stable',
+    '/images/beta/factory/': 'beta',
+    '/images/beta/other/': 'beta',
+    '/images/beta/sysupgrade/': 'beta',
+    '/images/testing/factory/': 'testing',
+    '/images/testing/other/': 'testing',
+    '/images/testing/sysupgrade/': 'testing',
   },
   // page title
   title: 'Firmware',


### PR DESCRIPTION
This patch series contains a few fixes to improve out-of-the-box usage of the repo:

- fixing the missing router.png in the Dockerfile
- improving the `config_template.js` so it's more clear and the output from a gluon build can be used directly in `directories` as well as making use of the `autoindex on` from the `nginx-vhost.conf` file.
- add an option to build the container without the images and instead use 3rd party images
- add a CI for both the Dockerbuild as well as some basic linting

The CI run can be seen here: https://github.com/grische/gluon-firmware-selector/actions/runs/24195090284

Closes #188 